### PR TITLE
205 Change Property in ObjectController to Indexer

### DIFF
--- a/Capstone/Assets/Game/Scripts/AbstractClasses/Character.cs
+++ b/Capstone/Assets/Game/Scripts/AbstractClasses/Character.cs
@@ -58,7 +58,7 @@ namespace Bladesmiths.Capstone
             // If the damaging object belongs to the same team as this character
             // Or if the damaging object has already hurt this character recently
             // Don't take any damage
-            if (objectController.IdentifiedObjects[damagingID].ObjectTeam == ObjectTeam || 
+            if (objectController[damagingID].ObjectTeam == ObjectTeam || 
                 DamagingObjectIDs.Contains(damagingID))
             {
                 damage = 0; 
@@ -74,7 +74,7 @@ namespace Bladesmiths.Capstone
             if (damage != 0)
             {
                 damagingObjectIDs.Add(damagingID);
-                ((IDamaging)objectController.IdentifiedObjects[damagingID].IdentifiedObject).DamagingFinished += RemoveDamagingID; 
+                ((IDamaging)objectController[damagingID].IdentifiedObject).DamagingFinished += RemoveDamagingID; 
             }
 
             // Log the amount of damage taken

--- a/Capstone/Assets/Game/Scripts/BlockCollision.cs
+++ b/Capstone/Assets/Game/Scripts/BlockCollision.cs
@@ -57,7 +57,7 @@ namespace Bladesmiths.Capstone
             {
                 // If the damaging object is not on the same team as the player
                 // And its ID has not already been blocked
-                if (ObjectController.IdentifiedObjects[damagingObject.ID].ObjectTeam != Enums.Team.Player && 
+                if (ObjectController[damagingObject.ID].ObjectTeam != Enums.Team.Player && 
                     !blockedObjectIDs.Contains(damagingObject.ID))
                 {
                     // Block has been triggered

--- a/Capstone/Assets/Game/Scripts/BossCylinder.cs
+++ b/Capstone/Assets/Game/Scripts/BossCylinder.cs
@@ -79,7 +79,7 @@ namespace Bladesmiths.Capstone
                     Player player = other.gameObject.transform.root.gameObject.GetComponent<Player>();
                     // Check if the player has already been hit by this object
                     //player.TakeDamage(id, damage);
-                    ((IDamageable)ObjectController.IdentifiedObjects[player.ID].IdentifiedObject).TakeDamage(ID, damage);
+                    ((IDamageable)ObjectController[player.ID].IdentifiedObject).TakeDamage(ID, damage);
                 }
 
                 damaging = true;

--- a/Capstone/Assets/Game/Scripts/EnemySwing.cs
+++ b/Capstone/Assets/Game/Scripts/EnemySwing.cs
@@ -135,7 +135,7 @@ namespace Bladesmiths.Capstone
                 else if (other.GetComponent<Player>() == true)
                 {
                     // Damage Player
-                    ((IDamageable)ObjectController.IdentifiedObjects[player.ID].IdentifiedObject).TakeDamage(ID, damage);
+                    ((IDamageable)ObjectController[player.ID].IdentifiedObject).TakeDamage(ID, damage);
 
                     damaging = true;
 

--- a/Capstone/Assets/Game/Scripts/ObjectController.cs
+++ b/Capstone/Assets/Game/Scripts/ObjectController.cs
@@ -19,7 +19,11 @@ namespace Bladesmiths.Capstone
         [OdinSerialize] [Tooltip("IDs mapped to Damageable Objects and their teams")]
         private Dictionary<int, IdentifiedTeamPair> identifiedObjects = new Dictionary<int, IdentifiedTeamPair>();
 
-        public Dictionary<int, IdentifiedTeamPair> IdentifiedObjects { get => identifiedObjects; }
+        // Indexer to return an identified pair from an id
+        public IdentifiedTeamPair this[int id]
+        {
+            get { return identifiedObjects[id]; }
+        }
 
         void Start()
         {

--- a/Capstone/Assets/Game/Scripts/Player.cs
+++ b/Capstone/Assets/Game/Scripts/Player.cs
@@ -727,7 +727,7 @@ namespace Bladesmiths.Capstone
         /// <param name="damage">The amount of damage to give to the target</param>
         public void SwordAttack(int targetID, float damage)
         {
-            ((IDamageable)ObjectController.IdentifiedObjects[targetID].IdentifiedObject).TakeDamage(ID, damage);
+            ((IDamageable)ObjectController[targetID].IdentifiedObject).TakeDamage(ID, damage);
 
             // Testing
             damaging = true;

--- a/Capstone/Assets/Game/Scripts/Testing/TestingProjectile.cs
+++ b/Capstone/Assets/Game/Scripts/Testing/TestingProjectile.cs
@@ -120,7 +120,7 @@ namespace Bladesmiths.Capstone.Testing
                 {
                     // Damage the player
                     //player.TakeDamage(ID, damage);
-                    ((IDamageable)ObjectController.IdentifiedObjects[player.ID].IdentifiedObject).TakeDamage(ID, damage);
+                    ((IDamageable)ObjectController[player.ID].IdentifiedObject).TakeDamage(ID, damage);
 
 
                     // Start a coroutine to change the player's material to show they've been damaged


### PR DESCRIPTION
• Deleted IdentifiedObjects Property in ObjectController that return the dictionary
• Created Indexer in ObjectController to allow for indexing directly into the ObjectController like `objectController[id]`

[Change IdentifiedObjects property in ObjectController to Indexer](https://app.gitkraken.com/glo/view/card/48449a45d8374b5d99a7057e2b0116cd)