### PR TITLE
277 Implement Provisional Damage Decay

### DIFF
--- a/Capstone/Assets/Game/Balancing/Balancing Data.asset
+++ b/Capstone/Assets/Game/Balancing/Balancing Data.asset
@@ -149,3 +149,6 @@ MonoBehaviour:
       Entry: 8
       Data: 
   swordSwitchingTime: 0
+  provisionalDamageDecayDelay: 4
+  provisionalDamageDecayTimeLimit: 0.5
+  provisionalDamageDecayRate: 1

--- a/Capstone/Assets/Game/Scripts/BalancingData.cs
+++ b/Capstone/Assets/Game/Scripts/BalancingData.cs
@@ -16,7 +16,17 @@ namespace Bladesmiths.Capstone
         [Header("Player")]
         // TODO: Implement Sword Switching Delay
         [SerializeField] [Tooltip("The time it takes to switch swords")]
-        private float swordSwitchingTime; 
+        private float swordSwitchingTime;
+
+        [SerializeField] [Tooltip("The time it takes for provisional damage to " +
+                                "start decaying once block has been released")]
+        private float provisionalDamageDecayDelay;
+
+        [SerializeField] [Tooltip("The time between each decay of provisional damage")]
+        private float provisionalDamageDecayTimeLimit;
+
+        [SerializeField] [Tooltip("The amount of provisional damage that is removed each decay")]
+        private float provisionalDamageDecayRate;
 
         [OdinSerialize] [Tooltip("The player's swords")]
         private Dictionary<Enums.SwordType, SwordData> swordData = new Dictionary<Enums.SwordType, SwordData>();
@@ -34,7 +44,10 @@ namespace Bladesmiths.Capstone
         #endregion
 
         #region Player Properties
-        public float SwordSwitchingTime => SwordSwitchingTime;
+        public float SwordSwitchingTime => swordSwitchingTime;
+        public float ProvisionalDamageDecayDelay => provisionalDamageDecayDelay;
+        public float ProvisionalDamageDecayTimeLimit => provisionalDamageDecayTimeLimit;
+        public float ProvisionalDamageDecayRate => provisionalDamageDecayRate;
         public Dictionary<Enums.SwordType, SwordData> SwordData => swordData;
         public Dictionary <Enums.SwordType, float> AttackAnimSpeeds => attackAnimSpeeds;
         #endregion

--- a/Capstone/Assets/Game/Scripts/Enemy.cs
+++ b/Capstone/Assets/Game/Scripts/Enemy.cs
@@ -49,7 +49,6 @@ namespace Bladesmiths.Capstone
 
         public float attackTimer;
         public float attackTimerMax;
-        private bool isBroken;
         public bool stunned;
 
         public float Damage { get => damage; }
@@ -78,7 +77,6 @@ namespace Bladesmiths.Capstone
         public virtual void Start()
         {
             AIDirector.Instance.AddToEnemyGroup(this);
-            isBroken = false;
             stunned = false;
             player = GameObject.Find("Player").GetComponent<Player>();
 

--- a/Capstone/Assets/Game/Scripts/ParryCollision.cs
+++ b/Capstone/Assets/Game/Scripts/ParryCollision.cs
@@ -6,23 +6,20 @@ namespace Bladesmiths.Capstone
 {
     public class ParryCollision : MonoBehaviour
     {
-        private Player player; 
+        private Player player;
 
         public ObjectController ObjectController { get; set; }
-        public float ChipDamageTotal { get; private set; }
+        public float ChipDamageTotal { get; set; }
 
         // Start is called before the first frame update
-        void Start()
+        public void Start()
         {
             ObjectController = GameObject.Find("ObjectController").GetComponent<ObjectController>();
             player = gameObject.transform.root.gameObject.GetComponent<Player>();
         }
 
         // Update is called once per frame
-        void Update()
-        {
-
-        }
+        void Update() { }
 
         /// <summary>
         /// Method hooked to block event that updates fields when a block occurs
@@ -32,6 +29,7 @@ namespace Bladesmiths.Capstone
         public void BlockOccured(float newChipDamageTotal)
         {
             ChipDamageTotal = newChipDamageTotal;
+            player.ResetProvisionalDamageTimers();
         }
 
         /// <summary>
@@ -78,14 +76,6 @@ namespace Bladesmiths.Capstone
                     ResetChipDamage(); 
                 }
             }
-        }
-
-        /// <summary>
-        /// Resets Chip Damage whenever this scipt is disabled
-        /// </summary>
-        private void OnDisable()
-        {
-            ResetChipDamage(); 
         }
     }
 }

--- a/Capstone/Assets/Game/Scripts/Player.cs
+++ b/Capstone/Assets/Game/Scripts/Player.cs
@@ -50,7 +50,6 @@ namespace Bladesmiths.Capstone
         [SerializeField]
         private Vector3 respawnRotation;
 
-
         [OdinSerialize]
         private Dictionary<PlayerCondition, float> speedValues = new Dictionary<PlayerCondition, float>();
 
@@ -106,6 +105,11 @@ namespace Bladesmiths.Capstone
         [OdinSerialize]
         private Dictionary<SwordType, GameObject> swords = new Dictionary<SwordType, GameObject>();
         private int animIDSwordChoice;
+        #endregion
+
+        #region Health-Related Fields
+        private float provisionalDamageDecayDelayTimer;
+        private float provisionalDamageDecayTimer;
         #endregion
 
         #region Damaging System Fields
@@ -249,6 +253,7 @@ namespace Bladesmiths.Capstone
 
             // Subscribing parry collision to block collision events to keep those fields updated
             blockDetector.GetComponent<BlockCollision>().OnBlock += parryDetector.GetComponent<ParryCollision>().BlockOccured;
+            parryDetector.GetComponent<ParryCollision>().Start();
 
             // Creates all of the states
             parryAttempt = new PlayerFSMState_PARRYATTEMPT(this, inputs, animator, parryDetector);
@@ -291,8 +296,9 @@ namespace Bladesmiths.Capstone
 
             currentSword = swords[SwordType.Quartz].GetComponent<Sword>();
             animIDSwordChoice = Animator.StringToHash("Sword Choice");
-        }
 
+            ResetProvisionalDamageTimers(); 
+        }
 
         private void Update()
         {
@@ -301,11 +307,14 @@ namespace Bladesmiths.Capstone
             Jump();
             Move();
 
+            DecayProvisionalDamage();
+
             // If the player is dead and just died (fadeToBlack is still occuring)
-            if(points >= maxPoints)
+            if (points >= maxPoints)
             {
                 FadeToBlack();
             }
+
         }
 
         /// <summary>
@@ -639,6 +648,47 @@ namespace Bladesmiths.Capstone
 
             // Return 0 if the player cannot currently be damaged
             return 0; 
+        }
+
+        /// <summary>
+        /// Checks and updates provisional damage timers and does provisional 
+        /// damage decay if necessary
+        /// </summary>
+        public void DecayProvisionalDamage()
+        {
+            provisionalDamageDecayDelayTimer -= Time.deltaTime;
+            if (provisionalDamageDecayDelayTimer <= 0)
+            {
+                provisionalDamageDecayTimer -= Time.deltaTime;
+            }
+
+            if (provisionalDamageDecayDelayTimer <= 0)
+            {
+                if (provisionalDamageDecayTimer <= 0)
+                {
+                    if (parryDetector.GetComponent<ParryCollision>().ChipDamageTotal >= 
+                        currentBalancingData.ProvisionalDamageDecayRate)
+                    {
+                        parryDetector.GetComponent<ParryCollision>().ChipDamageTotal -= 
+                            currentBalancingData.ProvisionalDamageDecayRate;
+                    }
+                    else
+                    {
+                        parryDetector.GetComponent<ParryCollision>().ChipDamageTotal = 0;
+                    }
+
+                    provisionalDamageDecayTimer = currentBalancingData.ProvisionalDamageDecayTimeLimit;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resets the 2 timers related to provisional damage
+        /// </summary>
+        public void ResetProvisionalDamageTimers()
+        {
+            provisionalDamageDecayDelayTimer = currentBalancingData.ProvisionalDamageDecayDelay;
+            provisionalDamageDecayTimer = currentBalancingData.ProvisionalDamageDecayTimeLimit;
         }
 
         /// <summary>


### PR DESCRIPTION
* Added variables to balancing data so we can control how quickly provisional damage should decay from there
* Added timers to Player to track decay
* Added logic in Player to remove provisional damage as time passes

* Note: There are still visual bugs related to this if you take damage while decaying or something, but I'm not sure how exactly we want that to look (I'm also not sure how to fix this), and there are other visual bugs anyway so I think we may just want a card to fix all of these

[Implement Chip Damage Decay](https://app.gitkraken.com/glo/view/card/b0862f2469a84519b1a31bb0e9ae6bec)