### PR TITLE
322 Tips and Tricks

### DIFF
--- a/Capstone/Assets/Packages/LowPolyFarmLite/LowPolyFarmLite_HDRP.unitypackage.meta
+++ b/Capstone/Assets/Packages/LowPolyFarmLite/LowPolyFarmLite_HDRP.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: be97bef901f1ebd4185c2df859103a7a
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Capstone/Assets/Packages/LowPolyFarmLite/LowPolyFarmLite_LWRP.unitypackage.meta
+++ b/Capstone/Assets/Packages/LowPolyFarmLite/LowPolyFarmLite_LWRP.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: c540ef8e9c5426546b94fe5ebcdf87b9
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Capstone/Assets/Packages/LowPolyFarmLite/LowPolyFarmLite_URP.unitypackage.meta
+++ b/Capstone/Assets/Packages/LowPolyFarmLite/LowPolyFarmLite_URP.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: d615feb22ee21274bbe2b5c037bd9d5d
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Capstone/Assets/Scenes/PlayerScene.unity
+++ b/Capstone/Assets/Scenes/PlayerScene.unity
@@ -4723,6 +4723,7 @@ GameObject:
   - component: {fileID: 125179846}
   - component: {fileID: 125179845}
   - component: {fileID: 125179844}
+  - component: {fileID: 125179848}
   m_Layer: 5
   m_Name: InfoPanel
   m_TagString: Untagged
@@ -4779,24 +4780,24 @@ MonoBehaviour:
     SerializationNodes:
     - Name: infoTextDictionary
       Entry: 7
-      Data: 0|System.Collections.Generic.Dictionary`2[[System.Int32, mscorlib],[System.String,
+      Data: 0|System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.String,
         mscorlib]], mscorlib
     - Name: comparer
       Entry: 7
-      Data: 1|System.Collections.Generic.GenericEqualityComparer`1[[System.Int32,
+      Data: 1|System.Collections.Generic.GenericEqualityComparer`1[[System.String,
         mscorlib]], mscorlib
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 12
-      Data: 11
+      Data: 15
     - Name: 
       Entry: 7
       Data: 
     - Name: $k
-      Entry: 3
-      Data: 0
+      Entry: 1
+      Data: move
     - Name: $v
       Entry: 1
       Data: Walk
@@ -4807,8 +4808,8 @@ MonoBehaviour:
       Entry: 7
       Data: 
     - Name: $k
-      Entry: 3
-      Data: 1
+      Entry: 1
+      Data: look
     - Name: $v
       Entry: 1
       Data: Look Around
@@ -4819,8 +4820,8 @@ MonoBehaviour:
       Entry: 7
       Data: 
     - Name: $k
-      Entry: 3
-      Data: 2
+      Entry: 1
+      Data: attack
     - Name: $v
       Entry: 1
       Data: Attack
@@ -4831,8 +4832,8 @@ MonoBehaviour:
       Entry: 7
       Data: 
     - Name: $k
-      Entry: 3
-      Data: 3
+      Entry: 1
+      Data: block
     - Name: $v
       Entry: 1
       Data: Block
@@ -4843,8 +4844,8 @@ MonoBehaviour:
       Entry: 7
       Data: 
     - Name: $k
-      Entry: 3
-      Data: 4
+      Entry: 1
+      Data: parry
     - Name: $v
       Entry: 1
       Data: Parry / Deflect
@@ -4855,8 +4856,8 @@ MonoBehaviour:
       Entry: 7
       Data: 
     - Name: $k
-      Entry: 3
-      Data: 5
+      Entry: 1
+      Data: roll
     - Name: $v
       Entry: 1
       Data: Dodge Roll
@@ -4867,8 +4868,8 @@ MonoBehaviour:
       Entry: 7
       Data: 
     - Name: $k
-      Entry: 3
-      Data: 6
+      Entry: 1
+      Data: form
     - Name: $v
       Entry: 1
       Data: Change Sword Form
@@ -4879,32 +4880,8 @@ MonoBehaviour:
       Entry: 7
       Data: 
     - Name: $k
-      Entry: 3
-      Data: 7
-    - Name: $v
       Entry: 1
-      Data: Smash all 8 Gem Clusters -
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 3
-      Data: 8
-    - Name: $v
-      Entry: 1
-      Data: Defeat both enemies! -
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 3
-      Data: 9
+      Data: menu
     - Name: $v
       Entry: 1
       Data: Open the Menu
@@ -4915,11 +4892,87 @@ MonoBehaviour:
       Entry: 7
       Data: 
     - Name: $k
-      Entry: 3
-      Data: 10
+      Entry: 1
+      Data: lifesteal
     - Name: $v
       Entry: 1
-      Data: In <color=#FFFF00>Topaz</color> form, your sword drains life from enemies.
+      Data: Your <color=#ffda57>Topaz</color> sword drains life from enemies -
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: armor
+    - Name: $v
+      Entry: 1
+      Data: Enemies cannot interrupt your <color=#ed0b00>Ruby</color> sword attacks
+        -
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: dash
+    - Name: $v
+      Entry: 1
+      Data: The <color=#526eff>Sapphire</color> sword improves your roll to a dash
+        -
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: target
+    - Name: $v
+      Entry: 1
+      Data: Target Enemy
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: chip
+    - Name: $v
+      Entry: 1
+      Data: Chip damage taken when blocking is restored by parrying -
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: damage
+    - Name: $v
+      Entry: 1
+      Data: Damage taken is decreased by <color=#ed0b00>Ruby</color> and increased
+        by <color=#526eff>Sapphire</color> -
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: restoreHealth
+    - Name: $v
+      Entry: 1
+      Data: Break <color=#a200ff>Amethyst</color> clusters to restore your health
+        -
     - Name: 
       Entry: 8
       Data: 
@@ -5004,6 +5057,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 125179842}
   m_CullTransparentMesh: 1
+--- !u!225 &125179848
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 125179842}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 0
+  m_BlocksRaycasts: 0
+  m_IgnoreParentGroups: 0
 --- !u!1 &127523495
 GameObject:
   m_ObjectHideFlags: 0
@@ -5827,7 +5892,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 136034365}
-  m_LocalRotation: {x: -0.018141463, y: 0.000000029802322, z: -0.000000007450581, w: 0.9998355}
+  m_LocalRotation: {x: -0.018141463, y: -0, z: 0.000000014901161, w: 0.9998355}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -16558,7 +16623,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 409920308}
-  m_LocalRotation: {x: 0.018189477, y: 0.000000029802326, z: -0.000000014901163, w: 0.9998346}
+  m_LocalRotation: {x: 0.018189507, y: 0.000000029802326, z: -0.000000014901163, w: 0.9998346}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -64228,7 +64293,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1573736001}
-  m_LocalRotation: {x: 0.19442774, y: 0.38968438, z: -0.0845396, w: 0.8962126}
+  m_LocalRotation: {x: 0.19442774, y: 0.38968438, z: -0.08453959, w: 0.89621264}
   m_LocalPosition: {x: -100.34541, y: 10.347, z: -54.367992}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
@@ -76887,7 +76952,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 18
+      Data: 19
     - Name: 
       Entry: 7
       Data: 
@@ -77101,6 +77166,18 @@ MonoBehaviour:
     - Name: $v
       Entry: 6
       Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: clickRightStick
+    - Name: $v
+      Entry: 10
+      Data: 481
     - Name: 
       Entry: 8
       Data: 
@@ -85126,7 +85203,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2110197243}
-  m_LocalRotation: {x: -0.000000014901159, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: -0.000000014901161, y: 0.000000029802322, z: -0.000000014901161, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:

--- a/Capstone/Assets/Scenes/Village_Gameplay.unity
+++ b/Capstone/Assets/Scenes/Village_Gameplay.unity
@@ -752,6 +752,11 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 14425515}
   m_Mesh: {fileID: 4300000, guid: 457eca26206b82d4abb8b1726747e9c3, type: 3}
+--- !u!4 &14593340 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+  m_PrefabInstance: {fileID: 1503836677}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &18070778
 GameObject:
   m_ObjectHideFlags: 0
@@ -3486,6 +3491,10 @@ PrefabInstance:
       value: Move Info Zone
       objectReference: {fileID: 0}
     - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textKey
+      value: move
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: kbmIndex
       value: s
       objectReference: {fileID: 0}
@@ -5200,6 +5209,105 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 177903310}
   m_Mesh: {fileID: 4300000, guid: 942d5b3010cc3bc4893eb45aeb204597, type: 3}
+--- !u!4 &179199726 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+  m_PrefabInstance: {fileID: 399520021}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &182179047
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1895715919}
+    m_Modifications:
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.77646816
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.6301565
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 281.877
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108332386945124158, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Size.x
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108332386945124158, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Size.z
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Name
+      value: Health Info Zone
+      objectReference: {fileID: 0}
+    - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textKey
+      value: restoreHealth
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: kbmIndex
+      value: none
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: infoPanel
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textIndex
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: gamepadIndex
+      value: none
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+--- !u!4 &182179048 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+  m_PrefabInstance: {fileID: 182179047}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &188432652
 GameObject:
   m_ObjectHideFlags: 0
@@ -7325,11 +7433,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 11.95
+      value: 9.3
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalPosition.y
@@ -7337,7 +7445,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 20.74
+      value: 20.6
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalRotation.w
@@ -7378,6 +7486,10 @@ PrefabInstance:
     - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_Name
       value: SwordForm Info Zone
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textKey
+      value: form
       objectReference: {fileID: 0}
     - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: kbmIndex
@@ -10359,6 +10471,11 @@ Transform:
   m_Father: {fileID: 362225756}
   m_RootOrder: 39
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &361822773 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+  m_PrefabInstance: {fileID: 2030401162}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &362225755
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11144,6 +11261,95 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 398926115}
   m_Mesh: {fileID: 4300000, guid: 457eca26206b82d4abb8b1726747e9c3, type: 3}
+--- !u!1001 &399520021
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1895715919}
+    m_Modifications:
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 14.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.5582001
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.82970643
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 247.863
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108332386945124158, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Size.x
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108332386945124158, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Size.z
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Name
+      value: Parry Info Zone
+      objectReference: {fileID: 0}
+    - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textKey
+      value: parry
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: kbmIndex
+      value: q
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: infoPanel
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textIndex
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: gamepadIndex
+      value: leftTrigger
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
 --- !u!1 &400214913
 GameObject:
   m_ObjectHideFlags: 0
@@ -22917,6 +23123,95 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 813905839}
   m_Mesh: {fileID: 4300000, guid: 8b9f6cf8c3bf7ef4c9d21174bb21a656, type: 3}
+--- !u!1001 &816025726
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1895715919}
+    m_Modifications:
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -91.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.09027079
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.9959173
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 190.358
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108332386945124158, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Size.x
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108332386945124158, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Size.z
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Name
+      value: Chip Info Zone
+      objectReference: {fileID: 0}
+    - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textKey
+      value: chip
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: kbmIndex
+      value: none
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: infoPanel
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textIndex
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: gamepadIndex
+      value: none
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
 --- !u!1 &819252369
 GameObject:
   m_ObjectHideFlags: 0
@@ -36624,6 +36919,10 @@ PrefabInstance:
       value: Look Info Zone
       objectReference: {fileID: 0}
     - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textKey
+      value: look
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: kbmIndex
       value: moveMouse
       objectReference: {fileID: 0}
@@ -36877,6 +37176,10 @@ PrefabInstance:
     - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_Name
       value: Attack Info Zone
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textKey
+      value: attack
       objectReference: {fileID: 0}
     - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: kbmIndex
@@ -42782,6 +43085,184 @@ Transform:
   m_Father: {fileID: 1269937513}
   m_RootOrder: 30
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1501206228
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1895715919}
+    m_Modifications:
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -87.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -101.47
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.4915818
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.87083143
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 238.889
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108332386945124158, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Size.x
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108332386945124158, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Size.z
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Name
+      value: Dash Info Zone
+      objectReference: {fileID: 0}
+    - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textKey
+      value: dash
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: kbmIndex
+      value: none
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: infoPanel
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textIndex
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: gamepadIndex
+      value: none
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+--- !u!1001 &1503836677
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1895715919}
+    m_Modifications:
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 47.82
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.09027079
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.9959173
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 190.358
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108332386945124158, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Size.x
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108332386945124158, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Size.z
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Name
+      value: Armor Info Zone
+      objectReference: {fileID: 0}
+    - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textKey
+      value: armor
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: kbmIndex
+      value: none
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: infoPanel
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textIndex
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: gamepadIndex
+      value: none
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
 --- !u!1 &1504692051
 GameObject:
   m_ObjectHideFlags: 0
@@ -43995,6 +44476,11 @@ Transform:
   m_Father: {fileID: 362225756}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1542043945 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+  m_PrefabInstance: {fileID: 1501206228}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1544222383
 GameObject:
   m_ObjectHideFlags: 0
@@ -44688,7 +45174,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalPosition.x
@@ -44741,6 +45227,10 @@ PrefabInstance:
     - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_Name
       value: Menu Info Zone
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textKey
+      value: menu
       objectReference: {fileID: 0}
     - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: kbmIndex
@@ -45928,6 +46418,11 @@ Transform:
   m_Father: {fileID: 1269937513}
   m_RootOrder: 105
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1613833297 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+  m_PrefabInstance: {fileID: 816025726}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1617294756
 GameObject:
   m_ObjectHideFlags: 0
@@ -49426,7 +49921,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalPosition.x
@@ -49478,7 +49973,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_Name
-      value: Dodge Info Zone
+      value: Roll Info Zone
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textKey
+      value: roll
       objectReference: {fileID: 0}
     - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: kbmIndex
@@ -50005,7 +50504,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalPosition.x
@@ -50061,7 +50560,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textKey
+      value: lifesteal
       objectReference: {fileID: 0}
     - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: kbmIndex
@@ -53617,12 +54120,18 @@ Transform:
   - {fileID: 1128935773}
   - {fileID: 1646530344}
   - {fileID: 1794851425}
+  - {fileID: 39357662}
   - {fileID: 2090099145}
   - {fileID: 1729777589}
   - {fileID: 1596176872}
+  - {fileID: 182179048}
+  - {fileID: 179199726}
   - {fileID: 982323534}
-  - {fileID: 39357662}
   - {fileID: 1917991422}
+  - {fileID: 14593340}
+  - {fileID: 1613833297}
+  - {fileID: 1542043945}
+  - {fileID: 361822773}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -56251,6 +56760,95 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2026407472}
   m_Mesh: {fileID: 4300000, guid: bca750044050e1144ba752d3ee6cfd05, type: 3}
+--- !u!1001 &2030401162
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1895715919}
+    m_Modifications:
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -42.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -79.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.35005796
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.9367281
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 139.018
+      objectReference: {fileID: 0}
+    - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108332386945124158, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Size.x
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108332386945124158, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Size.z
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Name
+      value: Damage Info Zone
+      objectReference: {fileID: 0}
+    - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textKey
+      value: damage
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: kbmIndex
+      value: none
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: infoPanel
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textIndex
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: gamepadIndex
+      value: none
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
 --- !u!1 &2030703650
 GameObject:
   m_ObjectHideFlags: 0
@@ -57957,11 +58555,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.62
+      value: -12.1
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalPosition.y
@@ -57969,11 +58567,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -6.6
+      value: -29.6
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.8362889
+      value: 0.9995867
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalRotation.x
@@ -57981,7 +58579,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.54828894
+      value: 0.028750535
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalRotation.z
@@ -57993,7 +58591,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 66.499
+      value: 3.295
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
@@ -58009,11 +58607,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_Name
-      value: Parry Info Zone
+      value: Target Info Zone
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textKey
+      value: target
       objectReference: {fileID: 0}
     - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: kbmIndex
-      value: q
+      value: middleClick
       objectReference: {fileID: 0}
     - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: infoPanel
@@ -58025,7 +58627,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: gamepadIndex
-      value: leftTrigger
+      value: clickRightStick
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
@@ -58405,11 +59007,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -17.55
+      value: -18
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalPosition.y
@@ -58417,11 +59019,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -48.37
+      value: -53.5
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7333378
+      value: 0.5739724
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalRotation.x
@@ -58429,7 +59031,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.6798645
+      value: -0.8188746
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalRotation.z
@@ -58441,7 +59043,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -85.666
+      value: -109.945
       objectReference: {fileID: 0}
     - target: {fileID: 122765574732898919, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
@@ -58449,15 +59051,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1108332386945124158, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_Size.x
-      value: 10
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108332386945124158, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: m_Size.y
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 1108332386945124158, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_Size.z
-      value: 10
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 2620429776408177611, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: m_Name
       value: Block Info Zone
+      objectReference: {fileID: 0}
+    - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
+      propertyPath: textKey
+      value: block
       objectReference: {fileID: 0}
     - target: {fileID: 6808986966062802600, guid: d1dc08b46dbbb8f4398aca72b3818e42, type: 3}
       propertyPath: kbmIndex

--- a/Capstone/Assets/Scripts/UI/InfoPanel.cs
+++ b/Capstone/Assets/Scripts/UI/InfoPanel.cs
@@ -18,6 +18,8 @@ public class InfoPanel : SerializedMonoBehaviour
     public Image infoImageR;
     public Image infoImageU;
 
+    private CanvasGroup canvasGroup;
+
     public TextMeshProUGUI infoText;
     public TextMeshProUGUI infoTextPlusL;
     public TextMeshProUGUI infoTextPlusR;
@@ -27,7 +29,7 @@ public class InfoPanel : SerializedMonoBehaviour
     [BoxGroup("Tutorial Text/FirstRow/Tutorial Text")] [LabelWidth(70)]
 
     [OdinSerialize]
-    Dictionary<int, string> infoTextDictionary = new Dictionary<int, string>();
+    Dictionary<string, string> infoTextDictionary = new Dictionary<string, string>();
 
     [SerializeField] UIManager uiManager;
     [SerializeField] PlayerInput playerInputs;
@@ -35,7 +37,7 @@ public class InfoPanel : SerializedMonoBehaviour
     private Dictionary<string, Sprite> xboxInputs;
     private Dictionary<string, Sprite> kbmInputs;
 
-    private int currentTextIndex;
+    private string currentTextKey;
     private string currentInputKBM;
     private string currentInputGamepad;
 
@@ -47,6 +49,7 @@ public class InfoPanel : SerializedMonoBehaviour
     {
         //firstCluster = GameObject.Find("Breakable Gem Cluster").GetComponent<BreakableBox>();
         //finalCluster = GameObject.Find("Breakable Gem Cluster (7)").GetComponent<LastBreakableBox>();
+        canvasGroup = GetComponent<CanvasGroup>();
 
         playerInputs = uiManager.Inputs;
         xboxInputs = uiManager.xboxInputs;
@@ -67,23 +70,62 @@ public class InfoPanel : SerializedMonoBehaviour
     {
         if (currentInputGamepad != null && currentInputKBM != null && withinZone)
         {
-            SetInfoUI(currentInputGamepad, currentInputKBM, currentTextIndex);
+            SetInfoUI(currentInputGamepad, currentInputKBM, currentTextKey);
+        }
+    }
+
+    public IEnumerator Fade(bool fadingIn)
+    {
+        //Fade In
+        if (fadingIn)
+        {
+            infoImage.enabled = true;
+            infoText.enabled = true;
+
+            infoTextPlusL.enabled = false;
+            infoTextPlusR.enabled = false;
+
+            infoImageLL.enabled = false;
+            infoImageL.enabled = false;
+            infoImageR.enabled = false;
+            infoImageU.enabled = false;
+
+            while (canvasGroup.alpha < 1.0f)
+            {
+                canvasGroup.alpha += Time.deltaTime;
+                yield return null;
+            }
+        }
+        //Fade Out
+        else
+        {
+            while (canvasGroup.alpha > 0.0f)
+            {
+                canvasGroup.alpha -= Time.deltaTime;
+                yield return null;
+            }
+
+            infoImage.sprite = null;
+            infoText.text = "";
+
+            infoImage.enabled = false;
+            infoText.enabled = false;
+
+            infoTextPlusL.enabled = false;
+            infoTextPlusR.enabled = false;
+
+            infoImageLL.enabled = false;
+            infoImageL.enabled = false;
+            infoImageR.enabled = false;
+            infoImageU.enabled = false;
         }
     }
 
     //Modify info panel image and text to display information
-    public void SetInfoUI(string gamepadIconIndex, string kbmIconIndex, int textIndex)
+    public void SetInfoUI(string gamepadIconIndex, string kbmIconIndex, string textKey)
     {
-        infoImage.enabled = true;
-        infoText.enabled = true;
-
-        infoTextPlusL.enabled = false;
-        infoTextPlusR.enabled = false;
-
-        infoImageLL.enabled = false;
-        infoImageL.enabled = false;
-        infoImageR.enabled = false;
-        infoImageU.enabled = false;
+        StopAllCoroutines();
+        StartCoroutine(Fade(true));
 
         //Only show a control icon if there's an icon to show
         if (gamepadIconIndex != "none" && kbmIconIndex != "none")
@@ -160,7 +202,7 @@ public class InfoPanel : SerializedMonoBehaviour
 
         //Set text
         //Determined entirely by an index value attached to the zone the player has entered
-        infoText.text = " - " + infoTextDictionary[textIndex];
+        infoText.text = " - " + infoTextDictionary[textKey];
 
         //Specific case for final cluster message
         //Hide text when enemies are defeated / cluster is active
@@ -177,24 +219,13 @@ public class InfoPanel : SerializedMonoBehaviour
 
         currentInputGamepad = gamepadIconIndex;
         currentInputKBM = kbmIconIndex;
-        currentTextIndex = textIndex;
+        currentTextKey = textKey;
     }
 
     //Hide info panel when not in use
     public void ClearInfoUI()
-    { 
-        infoImage.sprite = null;
-        infoText.text = "";
-
-        infoImage.enabled = false;
-        infoText.enabled = false;
-
-        infoTextPlusL.enabled = false;
-        infoTextPlusR.enabled = false;
-
-        infoImageLL.enabled = false;
-        infoImageL.enabled = false;
-        infoImageR.enabled = false;
-        infoImageU.enabled = false;
+    {
+        StopAllCoroutines();
+        StartCoroutine(Fade(false));
     }
 }

--- a/Capstone/Assets/Scripts/UI/InfoZone.cs
+++ b/Capstone/Assets/Scripts/UI/InfoZone.cs
@@ -7,7 +7,7 @@ public class InfoZone : MonoBehaviour
 {
     public string gamepadIndex;
     public string kbmIndex;
-    public int textIndex;
+    public string textKey;
 
     public InfoPanel infoPanel;
 
@@ -30,7 +30,7 @@ public class InfoZone : MonoBehaviour
         if (other.transform.root.gameObject.CompareTag("Player"))
         {
             infoPanel.withinZone = true;
-            infoPanel.SetInfoUI(gamepadIndex, kbmIndex, textIndex);
+            infoPanel.SetInfoUI(gamepadIndex, kbmIndex, textKey);
         }
     }
 


### PR DESCRIPTION
- Added fade in / out effect to messages
- Added 2 new tutorial messages for target lock and restoring health
- Added 5 tips and tricks messages at ends of optional paths
These explain:
- Topaz Lifesteal
- Ruby Attack Armor
- Chip Damage
- Sapphire Dash
- The fact that you take more / less damage depending on sword form

I didn't make any new scenes because I thought I could get away with it.
